### PR TITLE
Fix Pythonx.initialize_once/1 with custom directory

### DIFF
--- a/lib/pythonx.ex
+++ b/lib/pythonx.ex
@@ -183,10 +183,19 @@ defmodule Pythonx do
     Pythonx.Nif.initialize(python_home())
   end
 
-  def initialize_once(python_home \\ python_home()) do
+  def initialize_once(python_home) do
+    unless Pythonx.Nif.nif_loaded() do
+      Pythonx.Nif.load_nif({:custom, python_home})
+      Pythonx.Nif.initialize(python_home)
+    end
+
+    :ok
+  end
+
+  def initialize_once do
     unless Pythonx.Nif.nif_loaded() do
       Pythonx.Nif.load_nif(:embedded)
-      Pythonx.Nif.initialize(python_home)
+      Pythonx.Nif.initialize(python_home())
     end
 
     :ok


### PR DESCRIPTION
Currently using `Python.initialize_once("/my/python/dir")` sets python home, but still uses the embedded libpython3, which results in init failure if the minor versions differ.